### PR TITLE
#10-2/user challenge 기능 구현

### DIFF
--- a/src/main/java/TodoChallengers/BE/challenge/application/ChecklistService.java
+++ b/src/main/java/TodoChallengers/BE/challenge/application/ChecklistService.java
@@ -1,0 +1,43 @@
+package TodoChallengers.BE.challenge.application;
+
+import TodoChallengers.BE.challenge.dto.request.ChecklistRequestDto;
+import TodoChallengers.BE.challenge.entity.Challenge;
+import TodoChallengers.BE.challenge.entity.ChallengeChecklist;
+import TodoChallengers.BE.challenge.entity.Participant;
+import TodoChallengers.BE.challenge.repository.ChallengeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ChecklistService {
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    public Challenge createChecklist(ChecklistRequestDto requestDto){
+        UUID userId = UUID.fromString(requestDto.getUserId());
+        UUID challengeId = UUID.fromString(requestDto.getChecklist().getChallengeId());
+        Optional<Challenge> optionalChallenge = challengeRepository.findById(challengeId);
+        if(optionalChallenge.isPresent()){
+            Challenge challenge = optionalChallenge.get();
+
+            ChallengeChecklist checklist = ChallengeChecklist.builder()
+                    .checklistId(UUID.randomUUID())
+                    .checklistDate(requestDto.getChecklist().getChecklistDate())
+                    .checklistPhoto("asdf")
+                    .build();
+
+            for(Participant participant : challenge.getParticipants()){
+                if (participant.getParticipantId().equals(userId)) {
+                    participant.addChecklist(checklist);
+                    break;
+                }
+            }
+            return challengeRepository.save(challenge);
+        } else{
+            throw new IllegalArgumentException("챌린지 ㄴㄴ");
+        }
+    }
+}

--- a/src/main/java/TodoChallengers/BE/challenge/application/UserChallengeService.java
+++ b/src/main/java/TodoChallengers/BE/challenge/application/UserChallengeService.java
@@ -6,6 +6,7 @@ import TodoChallengers.BE.challenge.repository.ChallengeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,5 +25,20 @@ public class UserChallengeService {
         } else {
             throw new IllegalArgumentException("해당 챌린지가 존재하지 않습니다~");
         }
+    }
+
+    public Challenge quiteFromChallenge(UUID userId, UUID challengeId) {
+        Optional<Challenge> optionalChallenge = challengeRepository.findById(challengeId);
+        if (optionalChallenge.isPresent()) {
+            Challenge challenge = optionalChallenge.get();
+            challenge.getParticipants().removeIf(participant -> participant.getParticipantId().equals(userId));
+            return challengeRepository.save(challenge);
+        } else {
+            throw new IllegalArgumentException("해당 챌린지가 존재하지 않습니다~");
+        }
+    }
+
+    public List<Challenge> getAllUserChallenges(UUID userId) {
+        return challengeRepository.findByParticipantsParticipantId(userId);
     }
 }

--- a/src/main/java/TodoChallengers/BE/challenge/application/UserChallengeService.java
+++ b/src/main/java/TodoChallengers/BE/challenge/application/UserChallengeService.java
@@ -1,7 +1,28 @@
 package TodoChallengers.BE.challenge.application;
 
+import TodoChallengers.BE.challenge.entity.Challenge;
+import TodoChallengers.BE.challenge.entity.Participant;
+import TodoChallengers.BE.challenge.repository.ChallengeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class UserChallengeService {
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    public Challenge participateInChallenge(UUID userId, UUID challengeId) {
+        Optional<Challenge> optionalChallenge = challengeRepository.findById(challengeId);
+        if (optionalChallenge.isPresent()) {
+            Challenge challenge = optionalChallenge.get();
+            Participant participant = Participant.builder().participantId(userId).build();
+            challenge.getParticipants().add(participant);
+            return challengeRepository.save(challenge);
+        } else {
+            throw new IllegalArgumentException("해당 챌린지가 존재하지 않습니다~");
+        }
+    }
 }

--- a/src/main/java/TodoChallengers/BE/challenge/controller/ChallengeController.java
+++ b/src/main/java/TodoChallengers/BE/challenge/controller/ChallengeController.java
@@ -4,9 +4,11 @@ import TodoChallengers.BE.challenge.application.PublicChallengeService;
 import TodoChallengers.BE.challenge.application.UserChallengeService;
 import TodoChallengers.BE.challenge.dto.request.PublicChallengeRequestDto;
 import TodoChallengers.BE.challenge.entity.Challenge;
+import TodoChallengers.BE.challenge.entity.Participant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +24,8 @@ public class ChallengeController {
 
     @PostMapping("/challenge")
     public Challenge createChallenge(@RequestBody PublicChallengeRequestDto requestDto) {
+        UUID leaderId = UUID.fromString(requestDto.getChallengeLeaderId());
+
         Challenge challenge = Challenge.builder()
                 .id(UUID.randomUUID()) // 새로운 ID를 자동으로 생성
                 .challengeName(requestDto.getChallengeName())
@@ -29,8 +33,10 @@ public class ChallengeController {
                 .end(requestDto.getEnd())
                 .category(requestDto.getCategory())
                 .state("PUBLIC")
-                .challengeLeaderId(UUID.fromString(requestDto.getChallengeLeaderId()))
+                .challengeLeaderId(leaderId)
+                .participants(new HashSet<>())
                 .build();
+        challenge.getParticipants().add(Participant.builder().participantId(leaderId).build());
 
         return publicChallengeService.saveChallenge(challenge);
     }

--- a/src/main/java/TodoChallengers/BE/challenge/controller/ChallengeController.java
+++ b/src/main/java/TodoChallengers/BE/challenge/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package TodoChallengers.BE.challenge.controller;
 import TodoChallengers.BE.challenge.application.PublicChallengeService;
 import TodoChallengers.BE.challenge.application.UserChallengeService;
 import TodoChallengers.BE.challenge.dto.request.PublicChallengeRequestDto;
+import TodoChallengers.BE.challenge.dto.request.UserChallengeRequestDto;
 import TodoChallengers.BE.challenge.entity.Challenge;
 import TodoChallengers.BE.challenge.entity.Participant;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,10 @@ public class ChallengeController {
 
     @Autowired
     private UserChallengeService userChallengeService;
+
+    /*
+    * 현재 모집 중인 챌린지 관련
+    */
 
     @PostMapping("/challenge")
     public Challenge createChallenge(@RequestBody PublicChallengeRequestDto requestDto) {
@@ -69,5 +74,27 @@ public class ChallengeController {
     @DeleteMapping("/challenge/{id}")
     public void deleteChallenge(@PathVariable UUID id) {
         publicChallengeService.deleteChallenge(id);
+    }
+
+    /*
+    * 모집 중인 챌린지에 사용자 들어가기
+    */
+    @PostMapping("/user/challenge")
+    public Challenge participateChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+        UUID userId = UUID.fromString(requestDto.getUserId());
+        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+        return userChallengeService.participateInChallenge(userId,challengeId);
+    }
+
+    @DeleteMapping("/user/challenge")
+    public Challenge quiteChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+        UUID userId = UUID.fromString(requestDto.getUserId());
+        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+        return userChallengeService.quiteFromChallenge(userId,challengeId);
+    }
+
+    @GetMapping("/user/challenge/{userId}")
+    public List<Challenge> getChallengeByUserId(@PathVariable UUID userId) {
+        return userChallengeService.getAllUserChallenges(userId);
     }
 }

--- a/src/main/java/TodoChallengers/BE/challenge/controller/ChecklistController.java
+++ b/src/main/java/TodoChallengers/BE/challenge/controller/ChecklistController.java
@@ -1,0 +1,22 @@
+package TodoChallengers.BE.challenge.controller;
+
+import TodoChallengers.BE.challenge.application.ChecklistService;
+import TodoChallengers.BE.challenge.dto.request.ChecklistRequestDto;
+import TodoChallengers.BE.challenge.entity.Challenge;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+public class ChecklistController {
+    @Autowired
+    private ChecklistService checklistService;
+
+    @PostMapping("/checklist")
+    public Challenge certifyChecklist(@RequestBody ChecklistRequestDto requestDto){
+        return checklistService.createChecklist(requestDto);
+    }
+}

--- a/src/main/java/TodoChallengers/BE/challenge/controller/PublicChallengeController.java
+++ b/src/main/java/TodoChallengers/BE/challenge/controller/PublicChallengeController.java
@@ -15,13 +15,13 @@ import java.util.Optional;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api")
-public class ChallengeController {
+@RequestMapping("/api/public")
+public class PublicChallengeController {
     @Autowired
     private PublicChallengeService publicChallengeService;
 
-    @Autowired
-    private UserChallengeService userChallengeService;
+//    @Autowired
+//    private UserChallengeService userChallengeService;
 
     /*
     * 현재 모집 중인 챌린지 관련
@@ -79,22 +79,22 @@ public class ChallengeController {
     /*
     * 모집 중인 챌린지에 사용자 들어가기
     */
-    @PostMapping("/user/challenge")
-    public Challenge participateChallenge(@RequestBody UserChallengeRequestDto requestDto) {
-        UUID userId = UUID.fromString(requestDto.getUserId());
-        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
-        return userChallengeService.participateInChallenge(userId,challengeId);
-    }
-
-    @DeleteMapping("/user/challenge")
-    public Challenge quiteChallenge(@RequestBody UserChallengeRequestDto requestDto) {
-        UUID userId = UUID.fromString(requestDto.getUserId());
-        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
-        return userChallengeService.quiteFromChallenge(userId,challengeId);
-    }
-
-    @GetMapping("/user/challenge/{userId}")
-    public List<Challenge> getChallengeByUserId(@PathVariable UUID userId) {
-        return userChallengeService.getAllUserChallenges(userId);
-    }
+//    @PostMapping("/user/challenge")
+//    public Challenge participateChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+//        UUID userId = UUID.fromString(requestDto.getUserId());
+//        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+//        return userChallengeService.participateInChallenge(userId,challengeId);
+//    }
+//
+//    @DeleteMapping("/user/challenge")
+//    public Challenge quiteChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+//        UUID userId = UUID.fromString(requestDto.getUserId());
+//        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+//        return userChallengeService.quiteFromChallenge(userId,challengeId);
+//    }
+//
+//    @GetMapping("/user/challenge/{userId}")
+//    public List<Challenge> getChallengeByUserId(@PathVariable UUID userId) {
+//        return userChallengeService.getAllUserChallenges(userId);
+//    }
 }

--- a/src/main/java/TodoChallengers/BE/challenge/controller/UserChallengeController.java
+++ b/src/main/java/TodoChallengers/BE/challenge/controller/UserChallengeController.java
@@ -1,0 +1,36 @@
+package TodoChallengers.BE.challenge.controller;
+
+import TodoChallengers.BE.challenge.application.UserChallengeService;
+import TodoChallengers.BE.challenge.dto.request.UserChallengeRequestDto;
+import TodoChallengers.BE.challenge.entity.Challenge;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserChallengeController {
+    @Autowired
+    private UserChallengeService userChallengeService;
+
+    @PostMapping("/user/challenge")
+    public Challenge participateChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+        UUID userId = UUID.fromString(requestDto.getUserId());
+        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+        return userChallengeService.participateInChallenge(userId,challengeId);
+    }
+
+    @DeleteMapping("/user/challenge")
+    public Challenge quiteChallenge(@RequestBody UserChallengeRequestDto requestDto) {
+        UUID userId = UUID.fromString(requestDto.getUserId());
+        UUID challengeId = UUID.fromString(requestDto.getChallengeId());
+        return userChallengeService.quiteFromChallenge(userId,challengeId);
+    }
+
+    @GetMapping("/user/challenge/{userId}")
+    public List<Challenge> getChallengeByUserId(@PathVariable UUID userId) {
+        return userChallengeService.getAllUserChallenges(userId);
+    }
+}

--- a/src/main/java/TodoChallengers/BE/challenge/dto/request/ChecklistRequestDto.java
+++ b/src/main/java/TodoChallengers/BE/challenge/dto/request/ChecklistRequestDto.java
@@ -1,0 +1,24 @@
+package TodoChallengers.BE.challenge.dto.request;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Data
+@NoArgsConstructor
+public class ChecklistRequestDto {
+    private String userId;
+    //private String token;
+    private ChecklistDto checklist;
+    @Getter
+    @Data
+    @NoArgsConstructor
+    public static class ChecklistDto{
+        private String challengeId;
+        private Date checklistDate;
+        private String checklistPhoto;
+    }
+}

--- a/src/main/java/TodoChallengers/BE/challenge/dto/request/PublicChallengeRequestDto.java
+++ b/src/main/java/TodoChallengers/BE/challenge/dto/request/PublicChallengeRequestDto.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import java.util.Date;
 
 @Getter
-
 @Data
 @NoArgsConstructor
 public class PublicChallengeRequestDto {

--- a/src/main/java/TodoChallengers/BE/challenge/dto/request/UserChallengeRequestDto.java
+++ b/src/main/java/TodoChallengers/BE/challenge/dto/request/UserChallengeRequestDto.java
@@ -1,0 +1,12 @@
+package TodoChallengers.BE.challenge.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserChallengeRequestDto {
+    private String id; // 사용자 ID
+    //private String token; // 추후 추가 예정
+    private String challengeId;
+}

--- a/src/main/java/TodoChallengers/BE/challenge/dto/request/UserChallengeRequestDto.java
+++ b/src/main/java/TodoChallengers/BE/challenge/dto/request/UserChallengeRequestDto.java
@@ -1,12 +1,14 @@
 package TodoChallengers.BE.challenge.dto.request;
 
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Data
 @NoArgsConstructor
 public class UserChallengeRequestDto {
-    private String id; // 사용자 ID
+    private String userId; // 사용자 ID
     //private String token; // 추후 추가 예정
     private String challengeId;
 }

--- a/src/main/java/TodoChallengers/BE/challenge/dto/response/UserChallengeResponseDto.java
+++ b/src/main/java/TodoChallengers/BE/challenge/dto/response/UserChallengeResponseDto.java
@@ -1,0 +1,4 @@
+package TodoChallengers.BE.challenge.dto.response;
+
+public class UserChallengeResponseDto {
+}

--- a/src/main/java/TodoChallengers/BE/challenge/entity/Challenge.java
+++ b/src/main/java/TodoChallengers/BE/challenge/entity/Challenge.java
@@ -6,10 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nonapi.io.github.classgraph.json.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 @NoArgsConstructor
@@ -25,35 +22,6 @@ public class Challenge {
     private String category;
     private UUID challengeLeaderId;
     private String state;
-    private List<Participant> participants;
+    private Set<Participant> participants;
 }
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-class Participant {
-    private UUID participantId;
-    private List<ChallengeChecklist> challengeChecklist;
-}
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-class ChallengeChecklist {
-    private UUID checklistId;
-    private Date checklistDate;
-    private String checklistPhoto;
-    private String state;
-    private List<Reaction> reaction;
-}
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-class Reaction {
-    private UUID reactionId;
-    private UUID reactionGiverId;
-}

--- a/src/main/java/TodoChallengers/BE/challenge/entity/ChallengeChecklist.java
+++ b/src/main/java/TodoChallengers/BE/challenge/entity/ChallengeChecklist.java
@@ -1,0 +1,22 @@
+package TodoChallengers.BE.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeChecklist {
+    private UUID checklistId;
+    private Date checklistDate;
+    private String checklistPhoto;
+    private String state;
+    private List<Reaction> reaction;
+}

--- a/src/main/java/TodoChallengers/BE/challenge/entity/Participant.java
+++ b/src/main/java/TodoChallengers/BE/challenge/entity/Participant.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,4 +16,11 @@ import java.util.UUID;
 public class Participant {
     private UUID participantId;
     private List<ChallengeChecklist> challengeChecklist;
+
+    public void addChecklist(ChallengeChecklist checklist) {
+        if (this.challengeChecklist == null) {
+            this.challengeChecklist = new ArrayList<>();
+        }
+        this.challengeChecklist.add(checklist);
+    }
 }

--- a/src/main/java/TodoChallengers/BE/challenge/entity/Participant.java
+++ b/src/main/java/TodoChallengers/BE/challenge/entity/Participant.java
@@ -1,0 +1,18 @@
+package TodoChallengers.BE.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Participant {
+    private UUID participantId;
+    private List<ChallengeChecklist> challengeChecklist;
+}

--- a/src/main/java/TodoChallengers/BE/challenge/entity/Reaction.java
+++ b/src/main/java/TodoChallengers/BE/challenge/entity/Reaction.java
@@ -1,0 +1,17 @@
+package TodoChallengers.BE.challenge.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Reaction {
+    private UUID reactionId;
+    private UUID reactionGiverId;
+}

--- a/src/main/java/TodoChallengers/BE/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/TodoChallengers/BE/challenge/repository/ChallengeRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface ChallengeRepository extends MongoRepository<Challenge, UUID> {
     List<Challenge> findByState(String state);
+    List<Challenge> findByParticipantsParticipantId(UUID userId);
 }


### PR DESCRIPTION
## Summary
<!-- 작업한 내용을 간략히 설명합니다. -->

- user challenge, 원하는 챌린지에 사용자가 참여하는 것에 관한 api를 생성했습니다.
- 기존 하나의 challenge entity 파일에서 각 entity 접근을 위해  challenge, participant, challengecheklist, reaction 파일로 구분했습니다.
- controller와 service 또한 각 기능에 따라 파일을 나눴습니다.
- 챌린지 생성 시, 챌린지를 만든 사용자가 challengeleaderid 뿐 아니라 participant에도 자동으로 들어가게 수정했습니다.
- 예외처리 및 인증, 리액션 관련을 추가할 예정입니다.

<br/>

## Related Issue / Working Branch
<!-- 관련된 이슈, 작업 브랜치를 적습니다. -->

- #11 -2/feat
- 

<br/>

## Images (Optional)
<!-- 필요하다면 스크린샷을 첨부합니다. -->

-

<br/>

## Review Point (Optional)
<!-- 중점적으로 리뷰가 필요한 부분을 적습니다. 없다면 지워주세요. -->